### PR TITLE
BUG: sanitize_html_class() requires a string

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -278,7 +278,7 @@ function be_display_posts_shortcode( $atts ) {
 		}
 		
 		$class = array( 'listing-item' );
-		$class = sanitize_html_class( apply_filters( 'display_posts_shortcode_post_class', $class, $post, $listing, $original_atts ) );
+		$class = array_map( 'sanitize_html_class', apply_filters( 'display_posts_shortcode_post_class', $class, $post, $listing, $original_atts ) );
 		$output = '<' . $inner_wrapper . ' class="' . implode( ' ', $class ) . '">' . $image . $title . $date . $author . $excerpt . $content . '</' . $inner_wrapper . '>';
 		
 		// If post is set to private, only show to logged in users


### PR DESCRIPTION
Currently, DPS is passing an array to sanitize_html_class(), which only accepts a string ([WordPress Codex](http://codex.wordpress.org/Function_Reference/sanitize_html_class)).