### PR TITLE
New filter to change shortcode default behavior

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -326,7 +326,7 @@ function be_display_posts_shortcode( $atts ) {
  * @return array $out
  */
 function be_display_posts_off( $out, $pairs, $atts ) {
-	$out['display_posts_off'] = true;
+	$out['display_posts_off'] = apply_filters( 'display_posts_shortcode_inception_override', true );
 	return $out;
 }
 


### PR DESCRIPTION
I found myself wanting the date and excerpt to display by default without having to pass all of these "include..." attributes every time I used the shortcode. This should allow a dev to include a filter that will operate on any of the dozens of shortcode defaults according to their own preference, rather than the plugin creator's.
