### PR TITLE
Adds the abilitity to exclude child pages or posts

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -331,7 +331,7 @@ function be_display_posts_shortcode( $atts ) {
 	}
 	
 	// If post parent attribute, set up parent
-	if( $post_parent ) {
+	if( $post_parent !== false ) {
 		if( 'current' == $post_parent ) {
 			global $post;
 			$post_parent = get_the_ID();


### PR DESCRIPTION
By passing the argument [display-posts post_parent="0" ..] you are now able to exclude child pages or posts from being displayed.