### PR TITLE
Category Id Filter

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -69,6 +69,7 @@ function be_display_posts_shortcode( $atts ) {
 		'display_posts_off'   => false,
 		'excerpt_length'      => false,
 		'excerpt_more'        => false,
+		'excerpt_more_link'   => false,
 		'exclude_current'     => false,
 		'id'                  => false,
 		'ignore_sticky_posts' => false,
@@ -118,6 +119,7 @@ function be_display_posts_shortcode( $atts ) {
 	$date_query_compare  = sanitize_text_field( $atts['date_query_compare'] );
 	$excerpt_length      = intval( $atts['excerpt_length'] );
 	$excerpt_more        = sanitize_text_field( $atts['excerpt_more'] );
+	$excerpt_more_link   = filter_var( $atts['excerpt_more_link'], FILTER_VALIDATE_BOOLEAN );
 	$exclude_current     = filter_var( $atts['exclude_current'], FILTER_VALIDATE_BOOLEAN );
 	$id                  = $atts['id']; // Sanitized later as an array of integers
 	$ignore_sticky_posts = filter_var( $atts['ignore_sticky_posts'], FILTER_VALIDATE_BOOLEAN );
@@ -419,9 +421,24 @@ function be_display_posts_shortcode( $atts ) {
 			$author = apply_filters( 'display_posts_shortcode_author', ' <span class="author">by ' . get_the_author() . '</span>' );
 		
 		if ( $include_excerpt ) {
-			$excerpt_length = $excerpt_length ? $excerpt_length : apply_filters( 'excerpt_length', 55 );
-			$excerpt_more = $excerpt_more ? $excerpt_more : apply_filters( 'excerpt_more', ' ' . '[&hellip;]' );
-			$excerpt = ' <span class="excerpt-dash">-</span> <span class="excerpt">' . wp_trim_words( get_the_excerpt(), $excerpt_length, $excerpt_more ) . '</span>';
+			
+			// Custom build excerpt based on shortcode parameters
+			if( $excerpt_length || $excerpt_more || $excerpt_more_link ) {
+	
+				$length = $excerpt_length ? $excerpt_length : apply_filters( 'excerpt_length', 55 );
+				$more   = $excerpt_more ? $excerpt_more : apply_filters( 'excerpt_more', '' );
+				$more   = $excerpt_more_link ? ' <a href="' . get_permalink() . '">' . $more . '</a>' : ' ' . $more;
+				
+				$excerpt = has_excerpt() ? $post->post_excerpt . $more : wp_trim_words( $post->post_content, $length, $more );
+			
+			// Use default, can customize with WP filters
+			} else {
+				$excerpt = get_the_excerpt();
+			}
+			
+			$excerpt = ' <span class="excerpt-dash">-</span> <span class="excerpt">' . $excerpt . '</span>';			
+			
+			
 		}
 			
 		if( $include_content ) {

--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -54,6 +54,7 @@ function be_display_posts_shortcode( $atts ) {
 	$atts = shortcode_atts( array(
 		'title'              => '',
 		'author'              => '',
+		'categoryid'          => '',
 		'category'            => '',
 		'category_display'    => '',
 		'category_label'      => 'Posted in: ',
@@ -106,6 +107,7 @@ function be_display_posts_shortcode( $atts ) {
 	$shortcode_title     = sanitize_text_field( $atts['title'] );
 	$author              = sanitize_text_field( $atts['author'] );
 	$category            = sanitize_text_field( $atts['category'] );
+	$categoryid          = intval( $atts['categoryid'] );
 	$category_display    = 'true' == $atts['category_display'] ? 'category' : sanitize_text_field( $atts['category_display'] );
 	$category_label      = sanitize_text_field( $atts['category_label'] );
 	$content_class       = array_map( 'sanitize_html_class', ( explode( ' ', $atts['content_class'] ) ) );
@@ -156,6 +158,7 @@ function be_display_posts_shortcode( $atts ) {
 	// Set up initial query for post
 	$args = array(
 		'category_name'       => $category,
+		'cat'       	      => $categoryid,
 		'order'               => $order,
 		'orderby'             => $orderby,
 		'post_type'           => explode( ',', $post_type ),


### PR DESCRIPTION
Useful to use if you have a translation plugin that changes your category name and you'd rather use a category id.