### PR TITLE
Add language selection support to the shortcode & query.

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -67,6 +67,7 @@ function be_display_posts_shortcode( $atts ) {
 		'include_excerpt'      => false,
 		'include_link'         => true,
 		'include_title'        => true,
+		'lang'                 => get_locale(),
 		'meta_key'             => '',
 		'meta_value'           => '',
 		'no_posts_message'     => '',
@@ -122,6 +123,7 @@ function be_display_posts_shortcode( $atts ) {
 	$include_date_modified= filter_var( $atts['include_date_modified'], FILTER_VALIDATE_BOOLEAN );
 	$include_excerpt      = filter_var( $atts['include_excerpt'], FILTER_VALIDATE_BOOLEAN );
 	$include_link         = filter_var( $atts['include_link'], FILTER_VALIDATE_BOOLEAN );
+	$lang                 = sanitize_text_field( $atts['lang'] );
 	$meta_key             = sanitize_text_field( $atts['meta_key'] );
 	$meta_value           = sanitize_text_field( $atts['meta_value'] );
 	$no_posts_message     = sanitize_text_field( $atts['no_posts_message'] );
@@ -152,6 +154,7 @@ function be_display_posts_shortcode( $atts ) {
 	$args = array(
 		'cat'                 => $category_id,
 		'category_name'       => $category,
+		'lang'                => $lang,
 		'order'               => $order,
 		'orderby'             => $orderby,
 		'perm'                => 'readable',


### PR DESCRIPTION
This defaults to whatever get_locale() returns, but it also accepts `lang=""` for the default language or having lang be whatever the appropriate locale should be.

I ran into a site where they're using Polylang for multilingual content, but they had a page where they didn't want to have leave the language of the site the visitor's using while still only having one set of content to manage. The default behavior would keep the language of the currently viewed page even though I was specifying the ID of the content (which is unique for each language). The fix was to make it so the shortcode could accept & appropriately handle the lang query parameter.

I'd love to see this officially implemented in the plugin for future use.

As an aside, I've also posted about this on the WP.org support forum for others to potentially see: https://wordpress.org/support/topic/proposed-patch-add-language-selection-support-to-the-shortcode-query/

Thanks for the great plugin,
Kurt