### PR TITLE
Add `post-{id}` as a default class for a post item.

### DIFF
--- a/display-posts-shortcode.php
+++ b/display-posts-shortcode.php
@@ -594,7 +594,7 @@ function be_display_posts_shortcode( $atts ) {
 
 		}
 
-		$class = array( 'listing-item' );
+		$class = array( 'listing-item', 'post-' . get_the_ID() );
 
 		/**
 		 * Filter the post classes for the inner wrapper element of the current post.


### PR DESCRIPTION
Basically follows core parts of WP where the post ID is added as a class. Thanks in advance for your consideration to merge this pull request.